### PR TITLE
Expose Max.GetMaxCombo()

### DIFF
--- a/beatmap.go
+++ b/beatmap.go
@@ -20,7 +20,7 @@ type Map struct {
 	TPoints []*Timing
 }
 
-func (m *Map) maxCombo() int {
+func (m *Map) MaxCombo() int {
 	res := 0
 	tindex := -1
 	tnext := math.Inf(-1)

--- a/beatmap.go
+++ b/beatmap.go
@@ -20,7 +20,7 @@ type Map struct {
 	TPoints []*Timing
 }
 
-func (m *Map) MaxCombo() int {
+func (m *Map) GetMaxCombo() int {
 	res := 0
 	tindex := -1
 	tnext := math.Inf(-1)

--- a/pp.go
+++ b/pp.go
@@ -224,6 +224,37 @@ func (pp *PPv2) ppv2x(aimStars, speedStars float64,
 		pp.Speed *= pow(0.98, math.Max(0.0, (float64(n50)-float64(nobjects)/500.0)))
 	}
 
+	// Apply Aim/Speed Difference for relax/ap only
+
+	if (mods&ModsRX) != 0 || (mods&ModsAP) != 0 {
+		diff := math.Abs(math.Abs(pp.Speed) / math.Abs(pp.Aim))
+
+		if diff < 0.2 {
+			pp.Speed *= 0.1
+		} else if diff < 0.5 {
+			pp.Speed *= 0.25
+		} else if diff < 0.75 {
+			pp.Speed *= 0.5
+		} else if diff < 0.85 {
+			pp.Speed *= 0.66
+		}
+
+		if diff >= 0.85 {
+			pp.Speed *= 0.5
+		} else if diff > 0.95 {
+			pp.Speed *= 0.4
+		} else if diff > 1.2 {
+			pp.Speed *= 0.2
+		} else if diff > 1.5 {
+			pp.Speed *= 0.1
+		} else if diff > 2.0 {
+			pp.Speed *= 0.08
+		} else {
+			pp.Speed *= 0.04
+		}
+
+	}
+
 	/* acc pp ---------------------------------------------- */
 	pp.Acc = pow(1.52163, float64(mapstats.OD)) *
 		pow(realAcc, 24.0) * 2.83

--- a/pp.go
+++ b/pp.go
@@ -112,14 +112,10 @@ func (pp *PPv2) ppv2x(aimStars, speedStars float64,
 	/* global values --------------------------------------- */
 	nobjectsOver2k := float64(nobjects) / 2000.0
 
-	var lengthBonus float64
+	lengthBonus := 0.95 + 0.4*math.Min(1.0, nobjectsOver2k)
 
-	if (mods & ModsRX) != 0 {
-		lengthBonus = 0.95 + 0.4*math.Min(1.0, nobjectsOver2k)*1.1
-	} else if (mods & ModsAP) != 0 {
-		lengthBonus = 0.95 + 0.4*math.Min(1.0, nobjectsOver2k)*1.1
-	} else {
-		lengthBonus = 0.95 + 0.4*math.Min(1.0, nobjectsOver2k)
+	if (mods&ModsRX) != 0 || (mods&ModsAP) != 0 {
+		lengthBonus *= 1.1
 	}
 
 	if nobjects > 2000 {
@@ -223,7 +219,7 @@ func (pp *PPv2) ppv2x(aimStars, speedStars float64,
 	if (mods & ModsRX) != 0 {
 		pp.Speed *= pow(0.99, math.Max(0.0, (float64(n50)-float64(nobjects)/666.0)))
 	} else if (mods & ModsAP) != 0 {
-		pp.Speed *= pow(0.98, math.Max(0.0, (float64(n50)-float64(nobjects)/666.0)))
+		pp.Speed *= pow(0.7, math.Max(0.0, (float64(n50)-float64(nobjects)/666.0)))
 	} else {
 		pp.Speed *= pow(0.98, math.Max(0.0, (float64(n50)-float64(nobjects)/500.0)))
 	}

--- a/pp.go
+++ b/pp.go
@@ -47,7 +47,7 @@ func (pp *PPv2) ppv2x(aimStars, speedStars float64,
 		mode = beatmap.Mode
 		baseAR = beatmap.AR
 		baseOD = beatmap.OD
-		maxCombo = beatmap.MaxCombo()
+		maxCombo = beatmap.GetMaxCombo()
 		nsliders = beatmap.NSliders
 		ncircles = beatmap.NCircles
 		nobjects = len(beatmap.Objects)

--- a/pp.go
+++ b/pp.go
@@ -47,7 +47,7 @@ func (pp *PPv2) ppv2x(aimStars, speedStars float64,
 		mode = beatmap.Mode
 		baseAR = beatmap.AR
 		baseOD = beatmap.OD
-		maxCombo = beatmap.maxCombo()
+		maxCombo = beatmap.MaxCombo()
 		nsliders = beatmap.NSliders
 		ncircles = beatmap.NCircles
 		nobjects = len(beatmap.Objects)

--- a/utils.go
+++ b/utils.go
@@ -96,10 +96,12 @@ const (
 	ModsHD int = 1 << 3
 	ModsHR int = 1 << 4
 	ModsDT int = 1 << 6
+	ModsRX int = 1 << 7
 	ModsHT int = 1 << 8
 	ModsNC int = 1 << 9
 	ModsFL int = 1 << 10
 	ModsSO int = 1 << 12
+	ModsAP int = 1 << 13
 
 	ModsSpeedChanging = ModsDT | ModsHT | ModsNC
 	ModsMapChanging   = ModsHR | ModsEZ | ModsSpeedChanging
@@ -142,6 +144,12 @@ func ModsStr(mods int) string {
 	}
 	if (mods & ModsSO) != 0 {
 		s += "SO"
+	}
+	if (mods & ModsRX) != 0 {
+		s += "RX"
+	}
+	if (mods & ModsAP) != 0 {
+		s += "AP"
 	}
 	return s
 }


### PR DESCRIPTION
This PR will expose `(*map).GetMaxCombo()`, as opposed to the field `MaxCombo`

When trying to use this library, getting the max combo from a map is not possible as of right now, because the calculation of MaxCombo is only done internally when calling other methods.

For usability sake, this should honestly be a publicly accessible method, as done in this PR.

I have tested this (obviously). This leaves the old `MaxCombo` field exposed (which is Nobjects by default), but works fine.

Another way to achieve this would be calling the `maxCombo()` currently present in the codebase when parsing a beatmap to get an accurate MaxCombo value, but thats on you to decide.